### PR TITLE
Team Show page

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -12,7 +12,9 @@ Router.map(function() {
     this.route('edit', { path: '/:user_id/edit' });
   });
   this.route('users/login');
-  this.route('teams');
+  this.route('teams', function() {
+    this.route('show', { path: '/:team_id' });
+  });
   this.route('login');
   this.route('signup');
 });

--- a/app/routes/teams.js
+++ b/app/routes/teams.js
@@ -6,6 +6,6 @@ export default Ember.Route.extend({
   session: service(),
 
   model() {
-    return this.get('session.currentUser.teams');
+    return this.get('session.currentUser.teams').sortBy('teamName');
   }
 });

--- a/app/routes/teams/show.js
+++ b/app/routes/teams/show.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+/**
+  @class route:team
+  @extends Ember.Route
+ */
+export default Ember.Route.extend({
+  model(params) {
+    return this.store.find('team', params.team_id);
+  }
+});

--- a/app/templates/teams.hbs
+++ b/app/templates/teams.hbs
@@ -1,9 +1,11 @@
 Your teams are:
 <ul>
   {{#each model as |team|}}
-    <li>{{team.teamName}}</li>
+    <li>{{#link-to 'teams.show' team.id}}{{team.teamName}}{{/link-to}}</li>
     {{#each team.users as |user|}}
       {{user.username}}
     {{/each}}
   {{/each}}
 </ul>
+
+{{outlet}}

--- a/app/templates/teams/show.hbs
+++ b/app/templates/teams/show.hbs
@@ -1,0 +1,9 @@
+<h2>{{model.teamName}}</h2>
+
+<h4>Members of {{model.teamName}}</h4>
+
+<ul>
+  {{#each model.users as |user|}}
+    <li>{{#link-to 'users.show' user}}{{user.username}}{{/link-to}}</li>
+  {{/each}}
+</ul>

--- a/app/templates/teams/show.hbs
+++ b/app/templates/teams/show.hbs
@@ -1,9 +1,9 @@
-<h2>{{model.teamName}}</h2>
+<h2 data-test-team-name>{{model.teamName}}</h2>
 
 <h4>Members of {{model.teamName}}</h4>
 
 <ul>
-  {{#each model.users as |user|}}
-    <li>{{#link-to 'users.show' user}}{{user.username}}{{/link-to}}</li>
+  {{#each model.users as |user index|}}
+    <li data-test-username="{{index}}">{{#link-to 'users.show' user}}{{user.username}}{{/link-to}}</li>
   {{/each}}
 </ul>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -24,6 +24,9 @@ export default function() {
     http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
   */
 
+  this.get('/teams');
+  this.get('/teams/:id');
+
   this.get('/users/me', function(schema) {
     let user = schema.users.findBy({ email: "alice@example.com" });
     return user;

--- a/mirage/models/team.js
+++ b/mirage/models/team.js
@@ -1,5 +1,5 @@
 import { Model, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
-  teams: hasMany()
+  users: hasMany()
 });

--- a/tests/acceptance/team-show-test.js
+++ b/tests/acceptance/team-show-test.js
@@ -1,0 +1,48 @@
+/* global server */
+import { skip, test } from 'qunit';
+import moduleForAcceptance from 'assemble/tests/helpers/module-for-acceptance';
+import { authenticateSession } from 'assemble/tests/helpers/ember-simple-auth';
+import testSelector from 'ember-test-selectors';
+
+moduleForAcceptance('Acceptance | team-show', {
+  beforeEach() {
+    this.team1 = server.create('team', { teamName: 'The Fighting Mongooses' });
+    this.team2 = server.create('team', { teamName: 'The Springfield Isotopes' });
+    this.team3 = server.create('team', { teamName: 'The New New York Mets' });
+
+    server.create('user', { username: 'Alice', email: 'alice@example.com', teams: [this.team1, this.team3] });
+    server.create('user', { username: 'Laura', email: 'laura@example.com' , teams: [this.team1] });
+    server.create('user', { username: 'Marge', email: 'marge@example.com' , teams: [this.team1] });
+    server.create('user', { username: 'Maggie', email: 'maggie@example.com' , teams: [this.team2] });
+    server.create('user', { username: 'Patty', email: 'patty@example.com', teams: [this.team2] });
+
+    authenticateSession(this.application);
+  }
+});
+
+test("the page shows the team name", function(assert) {
+  visit(`/teams/${this.team1.id}`);
+
+  andThen(() => {
+    assert.equal(find(testSelector('team-name')).text(), 'The Fighting Mongooses');
+  });
+});
+
+test("the page lists the team's users", function(assert) {
+  visit(`/teams/${this.team1.id}`);
+
+  andThen(() => {
+    assert.equal(find(testSelector('username', 0)).text(), 'Alice');
+    assert.equal(find(testSelector('username', 1)).text(), 'Laura');
+    assert.equal(find(testSelector('username', 2)).text(), 'Marge');
+  });
+});
+
+skip("unauthenticated users", function(assert) {
+  // Assumes current user is alice@example.com
+  visit(`/teams/${this.team2.id}`);
+
+  andThen(() => {
+    assert.equal(find(testSelector('team-name')).length, 0, 'it does not render the page for users who are not part of the team');
+  });
+});


### PR DESCRIPTION
Closes #17 

Adds a team show page, displaying the name of the team, and a list of users on the team. Currently does not do anything with authentication- it expects the Rails server to control whether a visitor can see the team or not.